### PR TITLE
Hide the Ownership Viewer div in collapsed journal sidebars

### DIFF
--- a/styles/ownership_viewer.css
+++ b/styles/ownership_viewer.css
@@ -1,3 +1,7 @@
+aside.journal-sidebar.collapsed div.ownership-viewer {
+	display: none;
+}
+
 div.ownership-viewer {
 	max-width: max-content;
 	margin: auto 5px;


### PR DESCRIPTION
So as to not mess up page number display, closes #13 