### PR TITLE
fix: include all nested pages via [data-page-id]

### DIFF
--- a/scripts/ownership_viewer.js
+++ b/scripts/ownership_viewer.js
@@ -16,10 +16,10 @@ class OwnershipViewer {
 		let query = "li.directory-item.document";
 		if (isJournalSheet) {
 			collection = obj.object.collections.pages
-			query = "li.directory-item.level1";
+			query = "li.directory-item[data-page-id]";
 		} else if (isJournalEntrySheet) {
 			collection = data.document.collections.pages
-			query = "li.level1";
+			query = "li[data-page-id]";
 		}
 		const documentList = isJournalSheet ? html.find(query) : html.querySelectorAll(query);
 


### PR DESCRIPTION
**Before**
<img width="315" height="145" alt="image" src="https://github.com/user-attachments/assets/62c3d629-71e9-4100-bdc3-1a3405f85831" />

**After**
<img width="309" height="169" alt="image" src="https://github.com/user-attachments/assets/79e9c204-1da1-4920-af59-0e9791484d30" />

**Problem**
Ownership badges didn’t render for nested Journal pages (level2/level3).

**Fix**
Target all page levels using an attribute selector.


Could you also backport this to the v12? 
```
const documentList = html.find(
  isJournalSheet ? 'li.directory-item[data-page-id]' : 'li.directory-item.document'
);
```

