### PR TITLE
Fix ownership viewer click handler registration.

### DIFF
--- a/scripts/ownership_viewer.js
+++ b/scripts/ownership_viewer.js
@@ -115,10 +115,20 @@ class OwnershipViewer {
 			if (isJournalSheet || isJournalEntrySheet) {
 				// On journal sheets, delay registering click events until the page is selected and its header is expanded
 				Hooks.once("renderJournalEntrySheet", () => {
-					html.querySelectorAll(".ownership-viewer")?.forEach((el) => {
+					const ownershipElements = html.querySelectorAll?.(".ownership-viewer")
+						?? html.find?.(".ownership-viewer")?.toArray()
+						?? [];
+					for (const el of ownershipElements) {
 						el.addEventListener("click", clickEvent);
-					});
+					}
 				});
+			} else {
+				const ownershipElements = html.querySelectorAll?.(".ownership-viewer")
+					?? html.find?.(".ownership-viewer")?.toArray()
+					?? [];
+				for (const el of ownershipElements) {
+					el.addEventListener("click", clickEvent);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Added resilient click handler registration for the ownership viewer icons (using native/querySelector and jQuery fallbacks, including journal sheets) so clicking the icon reliably opens the ownership configuration again.

Fixes #24